### PR TITLE
Add static class name to cover

### DIFF
--- a/src/CropArea.ts
+++ b/src/CropArea.ts
@@ -734,7 +734,7 @@ export class CropArea {
 
     this.coverDiv = document.createElement('div');
 
-    this.coverDiv.className = this.styles.classNamePrefix;
+    this.coverDiv.classList.add(this.styles.classNamePrefix, this.styles.coverClassName);
 
     // hardcode font size so nothing inside is affected by higher up settings
     this.coverDiv.style.fontSize = '16px';

--- a/src/core/Style.ts
+++ b/src/core/Style.ts
@@ -6,11 +6,16 @@ import { IStyleSettings } from './IStyleSettings';
 export class StyleManager {
 
   private _classNamePrefix = '__cropro_';
+  private _coverClassName = 'cropro_cover';
   /**
    * Prefix used for all internally created CSS classes.
    */
   public get classNamePrefix(): string {
     return this._classNamePrefix;
+  }
+
+  public get coverClassName(): string {
+    return this._coverClassName;
   }
 
   private classes: StyleClass[] = [];


### PR DESCRIPTION
@ailon Right now there is no static class on the outer cropro wrapper. This is causing problems for me where I need to set the z-index of the element super high, because of another competing position absolute element. Adding this static class will make selecting it with CSS, easy.
